### PR TITLE
Generic `DataValue` type

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jirenius/go-res
 
-go 1.12
+go 1.22
 
 require (
 	github.com/dgraph-io/badger v1.6.2
@@ -10,5 +10,21 @@ require (
 	github.com/nats-io/nats-server/v2 v2.1.8
 	github.com/nats-io/nats.go v1.10.0
 	github.com/rs/xid v1.2.1
+)
+
+require (
+	github.com/AndreasBriese/bbloom v0.0.0-20190825152654-46b345b51c96 // indirect
+	github.com/cespare/xxhash v1.1.0 // indirect
+	github.com/dgraph-io/ristretto v0.0.2 // indirect
+	github.com/dustin/go-humanize v1.0.0 // indirect
+	github.com/golang/protobuf v1.4.0 // indirect
+	github.com/nats-io/jwt v0.3.2 // indirect
+	github.com/nats-io/nkeys v0.1.4 // indirect
+	github.com/nats-io/nuid v1.0.1 // indirect
+	github.com/pkg/errors v0.8.1 // indirect
 	github.com/stretchr/testify v1.6.1 // indirect
+	golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59 // indirect
+	golang.org/x/net v0.0.0-20190620200207-3b0461eec859 // indirect
+	golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e // indirect
+	google.golang.org/protobuf v1.22.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -41,10 +41,8 @@ github.com/jirenius/taskqueue v1.1.0 h1:V7Z/XeR515i96YmohoD1rXawAcGBONrd8+LGfckZ
 github.com/jirenius/taskqueue v1.1.0/go.mod h1:/x5dz4AGqzGI6FmIC+0rmbx6JBUGgJiQzb71JFy/JRg=
 github.com/jirenius/timerqueue v1.0.0 h1:TgcUQlrxKBBHYmStXPzLdMPJFfmqkWZZ1s7BA5G1d9E=
 github.com/jirenius/timerqueue v1.0.0/go.mod h1:pUEjy16BUruJMjLIsjWvWQh9Bu9CSXCIfGADZf37WIk=
-github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
-github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
@@ -109,7 +107,6 @@ google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzi
 google.golang.org/protobuf v1.22.0 h1:cJv5/xdbk1NnMPR1VP9+HU6gupuG9MLBoH1r6RHZ2MY=
 google.golang.org/protobuf v1.22.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=

--- a/types.go
+++ b/types.go
@@ -43,9 +43,12 @@ type SoftRef string
 // For strings, numbers, booleans, and null values, it marshals into a primitive value, eg.:
 //
 //	json.Marshal(res.DataValue{nil}) // Result: null
-type DataValue struct {
-	Data interface{} `json:"data"`
+type DataValue[T any] struct {
+	Data T `json:"data"`
 }
+
+// NewDataValue creates a new DataValue with the given data.
+func NewDataValue[T any](data T) DataValue[T] { return DataValue[T]{Data: data} }
 
 const (
 	refPrefix     = `{"rid":`


### PR DESCRIPTION
## Description

The goal of this MR is to use Go generics for the `DataValue` type to replace the `any` type of the `Data` field with a "concrete" type.

For example:

```go
type User struct {
  Profile *res.DataValue[*UserProfile] `json:"profile,omitempty"` // We can now use a "concrete" type.
}

type UserProfile struct {
  UserName string `json:"userName"`
}
```

To do that, I've done two things:
- Upgraded the Go version of the Go module to Go 1.22
- Updated the `DataValue` type (and added the `NewDataValue` function)

This MR changes the definition of the `DataValue` type but the change is quite simple:
```go
foo := &res.DataValue{Data: "foo"} // Before
bar := &res.DataValue[any]{Data: "bar"} // After (without really using Generics)

baz := res.NewDataValue("baz") // You can even use the NewDataValue function to infer the type parameter.
```

