### PR TITLE
Add the (*Error).DecodeData method

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,10 +1,22 @@
 package res
 
+import "encoding/json"
+
 // Error represents an RES error
 type Error struct {
-	Code    string      `json:"code"`
-	Message string      `json:"message"`
-	Data    interface{} `json:"data,omitempty"`
+	Code    string `json:"code"`
+	Message string `json:"message"`
+	Data    any    `json:"data,omitempty"`
+}
+
+// DecodeData into the given value.
+func (e *Error) DecodeData(value any) error {
+	rawData, err := json.Marshal(e.Data)
+	if err != nil {
+		return err
+	}
+
+	return json.Unmarshal(rawData, value)
 }
 
 func (e *Error) Error() string {


### PR DESCRIPTION
The goal of this method is to help decoding the data field of an error.

The problem is that the type conversion is not working in most cases. For example, the following code is not working:
```go
type User{}
user, ok := err.Data(*User)
// ...
```

We have to do:
```go
rawData, _ := json.Marshal(err.Data)

type User{}
user := &User{}

_ = json.Unmarshal(rawData, user)
```

Now, with this method, we can do:
```go
type User{}
user := &User{}
_ = err.DecodeData(user)
```

What do you think about that @jirenius?